### PR TITLE
[dev] build-docs: Set commit message in variable CI_COMMIT_MESSAGE

### DIFF
--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -30,6 +30,28 @@ runs:
       env:
         INPUT_GITHUB_TOOLS_URL: ${{ inputs.github-tools-url }}
         INPUT_GITHUB_TOOLS_BRANCH: ${{ inputs.github-tools-branch }}
+    # by default GitHub Actions does strange git merge with the Pull Request
+    # therefore clone vanilla function branch
+    - name: clone real function branch
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v4
+      with:
+        ref: "${{ github.event.pull_request.head.sha }}"
+        path: "real_branch"
+    - name: set commit message
+      if: ${{ github.event_name == 'pull_request' }}
+      # The EOF workaround is required because GitHub Actions parses the environment values 
+      # and has problems with new lines
+      # https://github.com/orgs/community/discussions/24952
+      run: |
+        cd real_branch
+        export CI_COMMIT_MESSAGE="$(git log --no-merges --format=%B -n 1 ${{ github.event.pull_request.head.sha }})"
+        echo -e "Commit message: \n${CI_COMMIT_MESSAGE}\n\n"
+        echo 'CI_COMMIT_MESSAGE<<EOF' >> $GITHUB_ENV
+        echo "$CI_COMMIT_MESSAGE" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+        cd .. && rm -r real_branch
+      shell: bash
     - name: set dev dependencies
       run: |
         $(julia --project=. /tmp/integration_test_tools/.ci/CI/src/GetProjectNameVersionPath.jl)


### PR DESCRIPTION
SetupDevEnv.jl reads custom dependency URLs from the git commit message. To enable the feature, it is required to set the environment variable.