### PR TITLE
[dev] fix the code, because GetProjectNameVersionPath.jl was moved to the script folder and uses the CI module

### DIFF
--- a/build-docs/action.yml
+++ b/build-docs/action.yml
@@ -54,11 +54,11 @@ runs:
       shell: bash
     - name: set dev dependencies
       run: |
-        $(julia --project=. /tmp/integration_test_tools/.ci/CI/src/GetProjectNameVersionPath.jl)
+        julia --project=/tmp/integration_test_tools/.ci/CI/ -e 'import Pkg; Pkg.instantiate()'
+        $(julia --project=/tmp/integration_test_tools/.ci/CI/ /tmp/integration_test_tools/.ci/CI/script/GetProjectNameVersionPath.jl $PWD)
         echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
         echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
         echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
-        julia --project=/tmp/integration_test_tools/.ci/CI/ -e 'import Pkg; Pkg.instantiate()'
         julia --project=/tmp/integration_test_tools/.ci/CI/ /tmp/integration_test_tools/.ci/CI/script/SetupDevEnv.jl docs/
         julia --project=docs/ -e 'import Pkg; Pkg.instantiate()'
       shell: bash


### PR DESCRIPTION
This PR and PR #9 run `julia --project=/tmp/integration_test_tools/.ci/CI/ -e 'import Pkg; Pkg.instantiate()'`. However is merged first, the second PR needs to be rebased, remove it's instantiate call and move the other instantiate call to the correct position. 